### PR TITLE
feat(server): fix Express 5 catch-all route for SPA fallback

### DIFF
--- a/viewer/server.mjs
+++ b/viewer/server.mjs
@@ -26,8 +26,9 @@ app.use(
     })
 );
 
-// SPA fallback (hash or history routing both supported)
-app.get("*", (_req, res) => {
+// modified for Express 5.x
+// SPA fallback: send index.html for any non-asset GET
+app.get(/.*/, (_req, res) => {
     res.sendFile(indexFile);
 });
 

--- a/viewer/src/components/ModelViewer.tsx
+++ b/viewer/src/components/ModelViewer.tsx
@@ -57,9 +57,10 @@ const ModelViewer: React.FC = () => {
     scene.add(directionalLight);
 
     const params = new URLSearchParams(window.location.search);
+    // 'https://raw.githubusercontent.com/kelvinwatson/glb-files/main/DamagedHelmet.glb';
     const modelUrl =
       params.get('fileUrl') ||
-      'https://raw.githubusercontent.com/kelvinwatson/glb-files/main/DamagedHelmet.glb';
+      'https://raw.githubusercontent.com/eapostol/lidar-web-app-viewer/main/sample/8_3_2025.ply';
     const ext = modelUrl.split('.').pop()?.toLowerCase();
     setLastUrl(modelUrl);
 


### PR DESCRIPTION
- Replace legacy app.get("*") with Express-5-safe catch-all (/.*/ or '/*').
- Prevent path-to-regexp error during startup on Render.
closes #10 